### PR TITLE
Fix binary output dir on OS X

### DIFF
--- a/lms/CMakeLists.txt
+++ b/lms/CMakeLists.txt
@@ -1,7 +1,13 @@
 project(LightWeightModularSystem)
 
 message("Compile core")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+if(APPLE)
+    # /bin suffix is needed on OS X
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+else()
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+endif()
 
 #include pugixml headers (hpp-files)
 include_directories(include)


### PR DESCRIPTION
Linking fails under OS X with RUNTIME_DIR = BINARY_DIR due to invalid target name .., hence a subdirectory for the output binaries is needed on OS X
