### PR TITLE
PrecisionTime Serialization

### DIFF
--- a/lms/include/lms/extra/time.h
+++ b/lms/include/lms/extra/time.h
@@ -21,6 +21,7 @@ std::string currentTimeString();
  */
 class PrecisionTime {
  public:
+    typedef std::int64_t TimeType;
     static const PrecisionTime ZERO;
 
     /**
@@ -51,7 +52,7 @@ class PrecisionTime {
      * @brief Get the time as microseconds.
      * @return microseconds
      */
-    std::int64_t micros() const;
+    TimeType micros() const;
 
     /**
      * @brief Construct a precision time from given
@@ -60,7 +61,7 @@ class PrecisionTime {
      * @param micros microseconds
      * @return precision time instance
      */
-    static PrecisionTime fromMicros(std::int64_t micros);
+    static PrecisionTime fromMicros(TimeType micros);
 
     /**
      * @brief Construct a precision time from given
@@ -69,7 +70,7 @@ class PrecisionTime {
      * @param millis milliseconds
      * @return precision time instance
      */
-    static PrecisionTime fromMillis(std::int64_t millis);
+    static PrecisionTime fromMillis(TimeType millis);
 
     /**
      * @brief Get time as floating point type
@@ -116,7 +117,7 @@ class PrecisionTime {
     bool operator ==(const PrecisionTime &t) const;
     bool operator !=(const PrecisionTime &t) const;
  private:
-    std::int64_t m_micros;
+    TimeType m_micros;
 
     /**
      * @brief Create a timestamp pointing to the given timestamp
@@ -124,7 +125,7 @@ class PrecisionTime {
      *
      * @param micros
      */
-    explicit PrecisionTime(std::int64_t micros);
+    explicit PrecisionTime(TimeType micros);
 };
 
 /**

--- a/lms/include/lms/extra/time.h
+++ b/lms/include/lms/extra/time.h
@@ -101,6 +101,24 @@ class PrecisionTime {
      * @return the remaining time (if interrupted) or zero
      */
     PrecisionTime sleep() const;
+    
+    /**
+     * Cereal save serialization function (using minimal save)
+     */
+    template <class Archive>
+    TimeType save_minimal( const Archive& ) const
+    {
+        return m_micros;
+    }
+
+    /**
+     * Cereal load serialization function (using minimal load)
+     */
+    template <class Archive>
+    void load_minimal( const Archive&, const TimeType& value )
+    {
+        m_micros = value;
+    }
 
     PrecisionTime operator +(const PrecisionTime &t) const;
     PrecisionTime operator -(const PrecisionTime &t) const;

--- a/lms/main/extra/time.cpp
+++ b/lms/main/extra/time.cpp
@@ -100,21 +100,21 @@ PrecisionTime PrecisionTime::sleep() const {
 
 const PrecisionTime PrecisionTime::ZERO(0);
 
-PrecisionTime::PrecisionTime(std::int64_t micros) : m_micros(micros) {
+PrecisionTime::PrecisionTime(PrecisionTime::TimeType micros) : m_micros(micros) {
 }
 
 PrecisionTime::PrecisionTime() : m_micros(0) {
 }
 
-std::int64_t PrecisionTime::micros() const {
+PrecisionTime::TimeType PrecisionTime::micros() const {
     return m_micros;
 }
 
-PrecisionTime PrecisionTime::fromMicros(std::int64_t micros) {
+PrecisionTime PrecisionTime::fromMicros(PrecisionTime::TimeType micros) {
     return PrecisionTime(micros);
 }
 
-PrecisionTime PrecisionTime::fromMillis(std::int64_t millis) {
+PrecisionTime PrecisionTime::fromMillis(PrecisionTime::TimeType millis) {
     return PrecisionTime(millis * 1000);
 }
 


### PR DESCRIPTION
Uses Cereal minimal split serialization (http://uscilab.github.io/cereal/serialization_functions.html#minimal)
