### PR TITLE
Removed implicit conversion from stream to bool...

### DIFF
--- a/lms/include/lms/module_config.h
+++ b/lms/include/lms/module_config.h
@@ -19,12 +19,7 @@ namespace lms {
 template<typename T>
 bool parse(const std::string &src, T &dst) {
     std::istringstream is(src);
-    // Microsoft VisualStudio and clang do not support operator bool on std::istream
-#if defined(_MSC_VER) || defined(__clang__)
     return !! (is >> dst);
-#else
-    return is >> dst;
-#endif
 }
 
 template<>


### PR DESCRIPTION
... since it was deprecated in C++11 and this was implemented in GCC v5+
in addition to clang / VisualStudio.
