### PR TITLE
Fix segfault on service lib loading error

### DIFF
--- a/lms/main/internal/framework.cpp
+++ b/lms/main/internal/framework.cpp
@@ -330,9 +330,11 @@ void Framework::installService(std::shared_ptr<ServiceWrapper> service) {
         logger.error("installService") << "Tried to install service "
             << service->name() << " but was already installed";
     } else {
-        services[service->name()] = service;
-        m_serviceLoader.load(service.get());
-        service->instance()->initBase(service.get(), logging::Level::DEBUG);
+        if(m_serviceLoader.load(service.get()))
+        {
+            service->instance()->initBase(service.get(), logging::Level::DEBUG);
+            services[service->name()] = service;
+        }
     }
 }
 


### PR DESCRIPTION
Previously, LMS would segfault when the lib of the service cannot be loaded (due to various reasons) because it is tried to create an instance even though the lib could not be loaded.

One might also want to stop the execution of the framework immediately if a lib cannot be found (doesn't seem to be the case currently?)
